### PR TITLE
Add set_reporter and unset_reporter to do split run

### DIFF
--- a/lib/mirage_logs.ml
+++ b/lib/mirage_logs.ml
@@ -105,6 +105,17 @@ module Make (C : V1.CLOCK) = struct
 
   let reporter t = t.reporter
 
+  let set_reporter t =
+    Logs.set_reporter t.reporter;
+    match t.ring with
+    | None -> ()
+    | Some _ ->
+      let old_hook = !Lwt.async_exception_hook in
+      Lwt.async_exception_hook := (fun ex ->
+          dump_ring t t.ch;
+          old_hook ex
+        )
+
   let run t fn =
     Logs.set_reporter t.reporter;
     match t.ring with

--- a/lib/mirage_logs.ml
+++ b/lib/mirage_logs.ml
@@ -8,11 +8,11 @@ let log_fmt = Format.formatter_of_buffer buf
 
 let string_of_level =
   let open Logs in function
-  | App -> "APP"
-  | Error -> "ERR"
-  | Warning -> "WRN"
-  | Info -> "INF"
-  | Debug -> "DBG"
+    | App -> "APP"
+    | Error -> "ERR"
+    | Warning -> "WRN"
+    | Info -> "INF"
+    | Debug -> "DBG"
 
 module Make (C : V1.CLOCK) = struct
   type ring_entry =
@@ -52,29 +52,29 @@ module Make (C : V1.CLOCK) = struct
   let log_to_ring time msg = function
     | None -> ()
     | Some ring ->
-        let i = ring.next in
-        ring.entries.(i) <- Entry (time, msg);
-        ring.next <-
-          if i = Array.length ring.entries - 1 then 0
-          else i + 1
+      let i = ring.next in
+      ring.entries.(i) <- Entry (time, msg);
+      ring.next <-
+        if i = Array.length ring.entries - 1 then 0
+        else i + 1
 
   let dump_ring t ch =
     match t.ring with
     | None -> ()
     | Some ring ->
-    Printf.fprintf ch "--- Dumping log ring buffer ---\n";
-    let first = ring.next in
-    let rec dump_from i =
-      begin match ring.entries.(i) with
-      | Unused -> ()
-      | Entry (time, msg) ->
-          Printf.fprintf ch "%s: %s\n%!" (fmt_timestamp time) msg;
-          ring.entries.(i) <- Unused end;
-      let next = i + 1 in
-      let next = if next = Array.length ring.entries then 0 else next in
-      if next <> first then dump_from next in
-    dump_from first;
-    Printf.fprintf ch "--- End dump ---\n%!"
+      Printf.fprintf ch "--- Dumping log ring buffer ---\n";
+      let first = ring.next in
+      let rec dump_from i =
+        begin match ring.entries.(i) with
+          | Unused -> ()
+          | Entry (time, msg) ->
+            Printf.fprintf ch "%s: %s\n%!" (fmt_timestamp time) msg;
+            ring.entries.(i) <- Unused end;
+        let next = i + 1 in
+        let next = if next = Array.length ring.entries then 0 else next in
+        if next <> first then dump_from next in
+      dump_from first;
+      Printf.fprintf ch "--- End dump ---\n%!"
 
   let all_debug _ = Logs.Debug
 
@@ -110,12 +110,12 @@ module Make (C : V1.CLOCK) = struct
     match t.ring with
     | None -> fn ()
     | Some _ ->
-        let old_hook = !Lwt.async_exception_hook in
-        Lwt.async_exception_hook := (fun ex ->
+      let old_hook = !Lwt.async_exception_hook in
+      Lwt.async_exception_hook := (fun ex ->
           dump_ring t t.ch;
           old_hook ex
         );
-        Lwt.finalize
-          (fun () -> Lwt.catch fn (fun ex -> dump_ring t t.ch; Lwt.fail ex))
-          (fun () -> Lwt.async_exception_hook := old_hook; Lwt.return ())
+      Lwt.finalize
+        (fun () -> Lwt.catch fn (fun ex -> dump_ring t t.ch; Lwt.fail ex))
+        (fun () -> Lwt.async_exception_hook := old_hook; Lwt.return ())
 end

--- a/lib/mirage_logs.mli
+++ b/lib/mirage_logs.mli
@@ -50,6 +50,10 @@ module Make (Clock : V1.CLOCK) : sig
   val set_reporter: t -> unit
   (** [set_reporter t] installs [t] as log reporter. *)
 
+  val unset_reporter: t -> unit
+  (** [unset_reporter t] remove the resources used when [t] has been
+      installed. *)
+
   val create :
     ?ch:out_channel ->
     ?ring_size:int ->

--- a/lib/mirage_logs.mli
+++ b/lib/mirage_logs.mli
@@ -5,31 +5,31 @@
 
     To use this reporter, add a call to [run] at the start of your program:
 
-{[
-module Logs_reporter = Mirage_logs.Make(Clock)
+    {[
+      module Logs_reporter = Mirage_logs.Make(Clock)
 
-let start () =
-  Logs.(set_level (Some Info));
-  Logs_reporter.(create () |> run) @@ fun () ->
-  ...
-]}
+      let start () =
+        Logs.(set_level (Some Info));
+        Logs_reporter.(create () |> run) @@ fun () ->
+        ...
+    ]}
 
     If you'd like to log only important messages to the console by default, but
     still get detailed logs on error:
 
-{[
-module Logs_reporter = Mirage_logs.Make(Clock)
+    {[
+      module Logs_reporter = Mirage_logs.Make(Clock)
 
-let console_threshold src =
-  match Logs.Src.name src with
-  | "noisy.library" -> Logs.Warning
-  | _ -> Logs.Info
+      let console_threshold src =
+        match Logs.Src.name src with
+        | "noisy.library" -> Logs.Warning
+        | _ -> Logs.Info
 
-let start () =
-  Logs.(set_level (Some Debug));
-  Logs_reporter.(create ~ring_size:20 ~console_threshold () |> run) @@ fun () ->
-  ...
-]}
+      let start () =
+        Logs.(set_level (Some Debug));
+        Logs_reporter.(create ~ring_size:20 ~console_threshold () |> run) @@ fun () ->
+        ...
+    ]}
 *)
 
 type threshold_config = Logs.src -> Logs.level

--- a/lib/mirage_logs.mli
+++ b/lib/mirage_logs.mli
@@ -47,6 +47,9 @@ module Make (Clock : V1.CLOCK) : sig
       the ring are dumped to provide extra context (and [Lwt.async_exception_hook]
       is also wrapped, to dump the ring for asynchronous exceptions). *)
 
+  val set_reporter: t -> unit
+  (** [set_reporter t] installs [t] as log reporter. *)
+
   val create :
     ?ch:out_channel ->
     ?ring_size:int ->

--- a/mirage_logs.docdir
+++ b/mirage_logs.docdir
@@ -1,1 +1,0 @@
-/home/user/work/cubieboard/mirage-logs/_build/lib/mirage_logs.docdir


### PR DESCRIPTION
It doesn't do anything with exception handling, but this can be simulated by printing a log message in the exception handler anyway.
