### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/mirage-logs.opam
+++ b/mirage-logs.opam
@@ -9,7 +9,7 @@ doc: "https://mirage.github.io/mirage-logs/"
 tags: ["org:mirage"]
 depends: [
   "ocaml" { >= "4.01.0"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "logs" { >= "0.5.0" }
   "ptime" { >= "0.8.1" }
   "mirage-clock" { >= "1.2.0"}


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.