### PR TITLE
remove usage of mirage-profile

### DIFF
--- a/mirage-logs.opam
+++ b/mirage-logs.opam
@@ -13,7 +13,6 @@ depends: [
   "logs" { >= "0.5.0" }
   "ptime" { >= "0.8.1" }
   "mirage-clock" { >= "3.0.0"}
-  "mirage-profile"
   "lwt"
   "alcotest" {with-test}
 ]

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,4 @@
 (library
   (name mirage_logs)
   (public_name mirage-logs)
-  (libraries logs mirage-clock lwt mirage-profile ptime))
+  (libraries logs mirage-clock lwt ptime))

--- a/src/mirage_logs.ml
+++ b/src/mirage_logs.ml
@@ -97,7 +97,6 @@ module Make (C : Mirage_clock.PCLOCK) = struct
         Buffer.clear buf;
         if level <= console_threshold src then
           Printf.fprintf ch "%s: %s\n%!" (fmt_timestamp (posix_time, tz)) msg;
-        MProf.Trace.label msg;
         log_to_ring posix_time tz msg ring;
         over ();
         k () in


### PR DESCRIPTION
Mirage profile used to be a great idea, and is a great predecessor to what is with the OCaml 5 runtime possible with the event infrastructure.

mirage-profile has not seen much maintenance or usage over the years, one reason is that the lwt-with-tracing hasn't been upstreamed. The usage of mirage-profile is questionable, esp. since there aren't any users, nor support outside of Xen.