### PR TITLE
Remove a substantial amount of code:

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,7 @@
 A reporter for the [Logs][] library that writes log messages to `stderr`, using
 a Mirage `CLOCK` to add timestamps.
 
-It can also log only important messages to the console, while writing all received messages to a ring buffer which is displayed if an exception occurs.
-
-If [Mirage tracing][] is enabled, it also writes each log message to the trace buffer.
-
 See `mirage_logs.mli` for details.
 
 [Logs]: http://erratique.ch/software/logs
-[Mirage tracing]: https://github.com/mirage/mirage-profile
 

--- a/mirage-logs.opam
+++ b/mirage-logs.opam
@@ -13,7 +13,7 @@ depends: [
   "logs" { >= "0.5.0" }
   "ptime" { >= "0.8.1" }
   "mirage-clock" { >= "3.0.0"}
-  "lwt"
+  "lwt" {with-test}
   "alcotest" {with-test}
 ]
 build: [
@@ -23,7 +23,5 @@ build: [
 ]
 synopsis: "A reporter for the Logs library that writes log messages to stderr, using a Mirage `CLOCK` to add timestamps"
 description: """
-It can also log only important messages to the console, while writing all received messages to a ring buffer which is displayed if an exception occurs.
-
-If tracing is enabled (via mirage-profile), it also writes each log message to the trace buffer.
+The Logs reporter prefixes each entry with a timestamp, and writes it to stderr.
 """

--- a/src/dune
+++ b/src/dune
@@ -2,4 +2,4 @@
  (name mirage_logs)
  (public_name mirage-logs)
  (modules mirage_logs)
- (libraries logs mirage-clock lwt ptime))
+ (libraries logs mirage-clock ptime))

--- a/src/mirage_logs.ml
+++ b/src/mirage_logs.ml
@@ -1,8 +1,6 @@
 (* Copyright (C) 2016, Thomas Leonard <thomas.leonard@unikernel.com>
    See the README file for details. *)
 
-type threshold_config = Logs.src -> Logs.level
-
 let buf = Buffer.create 200
 let log_fmt = Format.formatter_of_buffer buf
 
@@ -16,20 +14,6 @@ let string_of_level =
   | Debug -> "DBG"
 
 module Make (C : Mirage_clock.PCLOCK) = struct
-  type ring_entry = Unused | Entry of Ptime.t * int option * string
-  type ring = { entries : ring_entry array; mutable next : int }
-
-  type t = {
-    reporter : Logs.reporter;
-    ring : ring option;
-    ch : out_channel;
-    mutable old_hook : (exn -> unit) option;
-  }
-
-  let fmt_timestamp (posix_time, tz) =
-    let printer = Ptime.pp_human ?tz_offset_s:tz () in
-    Format.asprintf "%a" printer posix_time
-
   let pp_tags f tags =
     let pp tag () =
       let (Logs.Tag.V (def, value)) = tag in
@@ -38,46 +22,9 @@ module Make (C : Mirage_clock.PCLOCK) = struct
     in
     Logs.Tag.fold pp tags ()
 
-  let ring_buffer size =
-    let entries = Array.make size Unused in
-    { entries; next = 0 }
-
-  let log_to_ring time tz msg = function
-    | None -> ()
-    | Some ring ->
-        let i = ring.next in
-        ring.entries.(i) <- Entry (time, tz, msg);
-        ring.next <- (if i = Array.length ring.entries - 1 then 0 else i + 1)
-
-  let dump_ring t ch =
-    match t.ring with
-    | None -> ()
-    | Some ring ->
-        Printf.fprintf ch "--- Dumping log ring buffer ---\n";
-        let first = ring.next in
-        let rec dump_from i =
-          (match ring.entries.(i) with
-          | Unused -> ()
-          | Entry (posix_time, tz, msg) ->
-              Printf.fprintf ch "%s: %s\n%!"
-                (fmt_timestamp (posix_time, tz))
-                msg;
-              ring.entries.(i) <- Unused);
-          let next = i + 1 in
-          let next = if next = Array.length ring.entries then 0 else next in
-          if next <> first then dump_from next
-        in
-        dump_from first;
-        Printf.fprintf ch "--- End dump ---\n%!"
-
-  let all_debug _ = Logs.Debug
-
-  let create ?(ch = stderr) ?ring_size ?(console_threshold = all_debug) () =
-    let ring =
-      match ring_size with None -> None | Some size -> Some (ring_buffer size)
-    in
+  let create ?(ch = Format.err_formatter) () =
     let report src level ~over k msgf =
-      let tz = C.current_tz_offset_s () in
+      let tz_offset_s = C.current_tz_offset_s () in
       let posix_time = Ptime.v @@ C.now_d_ps () in
       let lvl = string_of_level level in
       msgf @@ fun ?header ?(tags = Logs.Tag.empty) fmt ->
@@ -87,9 +34,7 @@ module Make (C : Mirage_clock.PCLOCK) = struct
         Format.pp_print_flush log_fmt ();
         let msg = Buffer.contents buf in
         Buffer.clear buf;
-        if level <= console_threshold src then
-          Printf.fprintf ch "%s: %s\n%!" (fmt_timestamp (posix_time, tz)) msg;
-        log_to_ring posix_time tz msg ring;
+        Format.fprintf ch "%a: %s\n%!" (Ptime.pp_rfc3339 ?tz_offset_s ()) posix_time msg;
         over ();
         k ()
       in
@@ -98,47 +43,5 @@ module Make (C : Mirage_clock.PCLOCK) = struct
       | None -> Format.kfprintf k log_fmt ("%s [%s] " ^^ fmt) lvl src
       | Some h -> Format.kfprintf k log_fmt ("%s [%s:%s] " ^^ fmt) lvl src h
     in
-    let reporter = { Logs.report } in
-    let old_hook = None in
-    { reporter; ring; ch; old_hook }
-
-  let reporter t = t.reporter
-
-  let set_reporter t =
-    Logs.set_reporter t.reporter;
-    match t.ring with
-    | None -> ()
-    | Some _ ->
-        let old_hook = !Lwt.async_exception_hook in
-        t.old_hook <- Some old_hook;
-        Lwt.async_exception_hook :=
-          fun ex ->
-            dump_ring t t.ch;
-            old_hook ex
-
-  let unset_reporter t =
-    match t.old_hook with
-    | None -> ()
-    | Some h ->
-        Lwt.async_exception_hook := h;
-        t.old_hook <- None
-
-  let run t fn =
-    Logs.set_reporter t.reporter;
-    match t.ring with
-    | None -> fn ()
-    | Some _ ->
-        let old_hook = !Lwt.async_exception_hook in
-        (Lwt.async_exception_hook :=
-           fun ex ->
-             dump_ring t t.ch;
-             old_hook ex);
-        Lwt.finalize
-          (fun () ->
-            Lwt.catch fn (fun ex ->
-                dump_ring t t.ch;
-                Lwt.fail ex))
-          (fun () ->
-            Lwt.async_exception_hook := old_hook;
-            Lwt.return ())
+    { Logs.report }
 end

--- a/src/mirage_logs.ml
+++ b/src/mirage_logs.ml
@@ -34,7 +34,9 @@ module Make (C : Mirage_clock.PCLOCK) = struct
         Format.pp_print_flush log_fmt ();
         let msg = Buffer.contents buf in
         Buffer.clear buf;
-        Format.fprintf ch "%a: %s\n%!" (Ptime.pp_rfc3339 ?tz_offset_s ()) posix_time msg;
+        Format.fprintf ch "%a: %s\n%!"
+          (Ptime.pp_rfc3339 ?tz_offset_s ())
+          posix_time msg;
         over ();
         k ()
       in

--- a/src/mirage_logs.mli
+++ b/src/mirage_logs.mli
@@ -3,14 +3,10 @@
 
 (** MirageOS support for the Logs library.
 
-    This is the default log reporter used by MirageOS.
-*)
+    This is the default log reporter used by MirageOS. *)
 
 module Make (Clock : Mirage_clock.PCLOCK) : sig
-  val create :
-    ?ch:Format.formatter ->
-    unit ->
-    Logs.reporter
+  val create : ?ch:Format.formatter -> unit -> Logs.reporter
   (** [create ~ch ()] is a Logs reporter that logs to [ch] (defaults to
       [Format.err_formatter]), with time-stamps provided by [Clock].
 

--- a/src/mirage_logs.mli
+++ b/src/mirage_logs.mli
@@ -3,83 +3,18 @@
 
 (** MirageOS support for the Logs library.
 
-    To use this reporter, add a call to [run] at the start of your program:
-
-    {[
-      module Logs_reporter = Mirage_logs.Make(PClock)
-
-      let start () =
-        Logs.(set_level (Some Info));
-        Logs_reporter.(create () |> run) @@ fun () ->
-        ...
-    ]}
-
-    If you'd like to log only important messages to the console by default, but
-    still get detailed logs on error:
-
-    {[
-      module Logs_reporter = Mirage_logs.Make(PClock)
-
-      let console_threshold src =
-        match Logs.Src.name src with
-        | "noisy.library" -> Logs.Warning
-        | _ -> Logs.Info
-
-      let start () =
-        Logs.(set_level (Some Debug));
-        Logs_reporter.(create ~ring_size:20 ~console_threshold () |> run) @@ fun () ->
-        ...
-    ]} *)
-
-type threshold_config = Logs.src -> Logs.level
-(** A function that gives a threshold level for a given log source. Only
-    messages at or above the returned level will be processed. *)
+    This is the default log reporter used by MirageOS.
+*)
 
 module Make (Clock : Mirage_clock.PCLOCK) : sig
-  type t
-
-  val run : t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
-  (** [run t fn] installs the reporter [t] as the current [Logs] reporter and
-      runs [fn ()].
-
-      If [t] has a ring buffer and [fn] returns an error then the contents of
-      the ring are dumped to provide extra context (and
-      [Lwt.async_exception_hook] is also wrapped, to dump the ring for
-      asynchronous exceptions). *)
-
-  val set_reporter : t -> unit
-  (** [set_reporter t] installs [t] as log reporter. *)
-
-  val unset_reporter : t -> unit
-  (** [unset_reporter t] remove the resources used when [t] has been installed. *)
-
   val create :
-    ?ch:out_channel ->
-    ?ring_size:int ->
-    ?console_threshold:threshold_config ->
+    ?ch:Format.formatter ->
     unit ->
-    t
-  (** [create ~ch ~ring_size ~console_threshold ()] is a Logs reporter that logs
-      to [ch], with time-stamps provided by [Clock].
-
-      If [ring_size] is provided then each message that reaches the reporter is
-      also written to a ring buffer (with the given size).
-
-      If tracing is enabled then each log message that reaches the reporter is
-      also written to the trace buffer.
-
-      If [console_threshold] is provided then any message at or above the
-      returned threshold is also written to the console. If not provided, all
-      messages reaching the reporter are printed.
+    Logs.reporter
+  (** [create ~ch ()] is a Logs reporter that logs to [ch] (defaults to
+      [Format.err_formatter]), with time-stamps provided by [Clock].
 
       If logs are written faster than the backend can consume them, the whole
       unikernel will block until there is space (so log messages will not be
       lost, but unikernels generating a lot of log output may run slowly). *)
-
-  val reporter : t -> Logs.reporter
-  (** [reporter t] retrieves the {!Logs.reporter} value associated with {!t} *)
-
-  val dump_ring : t -> out_channel -> unit
-  (** [dump_ring t oc] writes all entries in the ring buffer to [oc] and clears
-      the ring. If [t] has no ring buffer, this function does nothing. *)
 end

--- a/test/test.ml
+++ b/test/test.ml
@@ -42,8 +42,7 @@ let test_console r =
       f ~tags:(tags ~src:"localhost" ~port:7000) "Packet rejected");
   Alcotest.(check string)
     "Tags"
-    "1970-01-01T00:00:00Z: WRN [test] Packet rejected: src=localhost \
-     port=7000"
+    "1970-01-01T00:00:00Z: WRN [test] Packet rejected: src=localhost port=7000"
     (input_line r);
   Log.debug (fun f -> f "Not shown")
 
@@ -60,11 +59,4 @@ let test () =
      test_console r;
      Lwt.return ())
 
-let () =
-  Alcotest.run "mirage-logs"
-    [
-      ( "Tests",
-        [
-          ("Logging", `Quick, test);
-        ] );
-    ]
+let () = Alcotest.run "mirage-logs" [ ("Tests", [ ("Logging", `Quick, test) ]) ]


### PR DESCRIPTION
- no "ring where log messages are buffered to"
- no custom types anymore (type t / set_reporter / unset_reporter / reporter)
- use Ptime.pp_rfc3339 for nicer output (esp. if time zone offset is None)

(this requires some changes in the mirage tool, but I'm fine to do them)

The ring and async_exception_hook was nice back in the days, nowadays it hasn't been used for a long time, so let's remove the rarely used code.

If there's need for re-adding such code, let's make it compositional in a separate library.